### PR TITLE
アプリケーションを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "sns-collaborator",
   "version": "1.0.0",
+  "type": "module",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -13,6 +14,6 @@
     "discord.js": "^14.16.2",
     "dotenv": "^16.4.5",
     "express": "^4.21.0",
-    "twitter-api-v2": "^1.17.2"
+    "misskey-js": "^2024.9.0-alpha.12"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,59 @@
+// 必要なモジュールのインポート
+import dotenv from 'dotenv';
+import express from 'express';
+import { Client, GatewayIntentBits } from 'discord.js';
+import * as Misskey from 'misskey-js';
+
+// 環境変数のロード
+dotenv.config();
+
+// 環境変数の取得
+const {
+    DISCORD_TOKEN,
+    DISCORD_CHANNEL_ID,
+    MISSKEY_INSTANCE_URL,
+    MISSKEY_API_TOKEN,
+    PORT,
+} = process.env;
+
+const app = express();
+app.get('/', (req, res) => {
+    res.send('Discord to Misskey Bot is running.');
+});
+
+// Discordクライアントの作成
+const discordClient = new Client({
+    intents: [
+        GatewayIntentBits.Guilds,
+        GatewayIntentBits.GuildMessages,
+        GatewayIntentBits.MessageContent,
+    ],
+});
+
+// Misskeyクライアントの作成
+const misskeyClient = new Misskey.api.APIClient({
+    origin: MISSKEY_INSTANCE_URL,
+    credential: MISSKEY_API_TOKEN,
+});
+
+// Discordのイベントキャッチ
+discordClient.on('messageCreate', async (message) => {
+    // ボット自身のメッセージや指定されたチャンネル以外のメッセージは無視
+    if (message.author.bot || message.channel.id !== DISCORD_CHANNEL_ID) return;
+    try {
+        await misskeyClient.request('notes/create', {
+            text: message.content,
+        });
+        console.log('Misskeyへの投稿が成功しました。');
+    } catch (error) {
+        console.error('Misskeyへの投稿に失敗しました:', error);
+    }
+});
+
+// Discordクライアントのログイン
+discordClient.login(DISCORD_TOKEN);
+
+// サーバーの起動
+app.listen(PORT, () => {
+    console.log(`Server is running on port ${PORT}`);
+});


### PR DESCRIPTION
### やったこと
Discordの特定の部屋に投げられたメッセージをMisskeyに流すアプリケーションを作った

### 動作確認
1. Discord Botの設定
  a. Discord Developer Portalにアクセスして新しいアプリケーションを作成
  b. Botの作成：Botセクションに移動して新しいボットを作成
  c. Botトークンの取得
  d. インテントの設定：MESSAGE CONTENT INTENT を有効にする
  e. Botの招待：以下のURLを使用して、ボットをサーバーに招待する
```
https://discord.com/oauth2/authorize?client_id=<クライアントID>&scope=bot&permissions=1024
```

2. アプリケーションのルートに `.env` ファイル作る
```sh
PORT=5000 # 好きなポート

DISCORD_CHANNEL_ID=<チャンネルID>
DISCORD_TOKEN=<DISCORD_TOKEN>

MISSKEY_INSTANCE_URL=https://misskey.io
MISSKEY_API_TOKEN=<MISSKEY_API_TOKEN>
```

3. アプリケーション起動
```sh
# node入れてる前提で
$ npm install
$ node src/app.js
```

4. Discord該当チャンネルにメッセージ投稿